### PR TITLE
Use instanceof to check for Uint8Array in cipher.encrypt.

### DIFF
--- a/Cipher.js
+++ b/Cipher.js
@@ -111,7 +111,7 @@ export class Cipher {
    * @return {Promise<Object>} resolves to a JWE.
    */
   async encrypt({data, recipients, keyResolver}) {
-    if(typeof data !== Uint8Array && typeof data !== 'string') {
+    if(!(data instanceof Uint8Array) && typeof data !== 'string') {
       throw new TypeError('"data" must be a Uint8Array or a string.');
     }
     if(data) {


### PR DESCRIPTION
Looks like one check for Uint8Array is wrong.
I did a grep of the files and could not find any other instances of 

```
    if(typeof data !== Uint8Array && typeof data !== 'string') {
```

