### PR TITLE
Add tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,9 @@
 module.exports = {
   root: true,
-  extends: ['eslint-config-digitalbazaar'],
+  extends: [
+    'eslint-config-digitalbazaar',
+    'eslint-config-digitalbazaar/jsdoc'
+  ],
   env: {
     node: true
   },

--- a/Cipher.js
+++ b/Cipher.js
@@ -19,11 +19,11 @@ export class Cipher {
    * indicates whether a FIPS-compliant algorithm or the latest recommended
    * algorithm will be used.
    *
-   * @param {String} [version='recommended'] `fips` to use a FIPS-compliant
+   * @param {string} [version='recommended'] - `fips` to use a FIPS-compliant
    *   algorithm, `recommended` to use the latest recommended algorithm when
    *   encrypting.
    *
-   * @return {Cipher}.
+   * @returns {Cipher} A Cipher used to encrypt and decrypt data.
    */
   constructor({version = 'recommended'} = {}) {
     if(typeof version !== 'string') {
@@ -53,14 +53,15 @@ export class Cipher {
    * in the `recipients` array will be updated to include the generated
    * ephemeral ECDH key.
    *
-   * @param {Array} recipients an array of recipients for the encrypted
-   *   content.
-   * @param {function} keyResolver a function that returns a Promise
+   * @param {object} options - The options for the stream.
+   * @param {Array} options.recipients
+   * - An array of recipients for the encrypted content.
+   * @param {Function} options.keyResolver - A function that returns a Promise
    *   that resolves a key ID to a DH public key.
-   * @param {number} [chunkSize=1048576] the size, in bytes, of the chunks to
-   *   break the incoming data into.
+   * @param {number} [options.chunkSize=1048576]
+   * - The size, in bytes, of the chunks to break the incoming data into.
    *
-   * @return {Promise<TransformStream>} resolves to a TransformStream.
+   * @returns {Promise<TransformStream>} Resolves to a TransformStream.
    */
   async createEncryptStream({recipients, keyResolver, chunkSize}) {
     const transformer = await this.createEncryptTransformer(
@@ -81,10 +82,11 @@ export class Cipher {
    * (KEK) generated via a shared secret between an ephemeral ECDH key and a
    * static ECDH key (ECDH-ES).
    *
-   * @param {Object} keyAgreementKey a key agreement key API with `id` and
-   *   `deriveSecret`.
+   * @param {object} options - Options for createDecryptStream.
+   * @param {object} options.keyAgreementKey
+   * - A key agreement key API with `id` and deriveSecret`.
    *
-   * @return {Promise<TransformStream>} resolves to the TransformStream.
+   * @returns {Promise<TransformStream>} Resolves to the TransformStream.
    */
   async createDecryptStream({keyAgreementKey}) {
     const transformer = await this.createDecryptTransformer(
@@ -102,13 +104,14 @@ export class Cipher {
    * in the `recipients` array will be updated to include the generated
    * ephemeral ECDH key.
    *
-   * @param {Uint8Array|String} [data] the data to encrypt.
-   * @param {Array} recipients an array of recipients for the encrypted
-   *   content.
-   * @param {function} keyResolver a function that returns a Promise
+   * @param {object} options - Options for encrypt.
+   * @param {Uint8Array|string} [options.data] - The data to encrypt.
+   * @param {Array} options.recipients
+   * - An array of recipients for the encrypted content.
+   * @param {Function} options.keyResolver - A function that returns a Promise
    *   that resolves a key ID to a DH public key.
    *
-   * @return {Promise<Object>} resolves to a JWE.
+   * @returns {Promise<object>} Resolves to a JWE.
    */
   async encrypt({data, recipients, keyResolver}) {
     if(!(data instanceof Uint8Array) && typeof data !== 'string') {
@@ -126,9 +129,9 @@ export class Cipher {
    * Encrypts an object. The object will be serialized to JSON and passed
    * to `encrypt`. See `encrypt` for other parameters.
    *
-   * @param {Object} obj the object to encrypt.
+   * @param {object} obj - The object to encrypt.
    *
-   * @return {Promise<Object>} resolves to a JWE.
+   * @returns {Promise<object>} Resolves to a JWE.
    */
   async encryptObject({obj, ...rest}) {
     if(typeof obj !== 'object') {
@@ -147,11 +150,13 @@ export class Cipher {
    * (KEK) generated via a shared secret between an ephemeral ECDH key and a
    * static ECDH key (ECDH-ES).
    *
-   * @param {Object} jwe the JWE to decrypt.
-   * @param {Object} keyAgreementKey a key agreement key API with `id` and
+   * @param {object} options - Options for decrypt.
+   * @param {object} options.jwe - The JWE to decrypt.
+   * @param {object} options.keyAgreementKey
+   * - A key agreement key API with `id` and
    *   `deriveSecret`.
    *
-   * @return {Promise<Uint8Array|null>} resolves to the decrypted data
+   * @returns {Promise<Uint8Array|null>} Resolves to the decrypted data
    *   or `null` if the decryption failed.
    */
   async decrypt({jwe, keyAgreementKey}) {
@@ -164,11 +169,12 @@ export class Cipher {
    * Decrypts a JWE that must contain an encrypted object. This method will
    * call `decrypt` and then `JSON.parse` the resulting decrypted UTF-8 data.
    *
-   * @param {Object} jwe the JWE to decrypt.
-   * @param {Object} keyAgreementKey a key agreement key API with `id` and
-   *   `deriveSecret`.
+   * @param {object} options - Options.
+   * @param {object} options.jwe - The JWE to decrypt.
+   * @param {object} options.keyAgreementKey
+   * - A key agreement key API with `id` and `deriveSecret`.
    *
-   * @return {Promise<Object|null>} resolves to the decrypted object or `null`
+   * @returns {Promise<object|null>} Resolves to the decrypted object or `null`
    *   if the decryption failed.
    */
   async decryptObject({jwe, keyAgreementKey}) {
@@ -190,14 +196,16 @@ export class Cipher {
    * in the `recipients` array will be updated to include the generated
    * ephemeral ECDH key.
    *
-   * @param {Array} recipients an array of recipients for the encrypted
-   *   content.
-   * @param {function} keyResolver a function that returns a Promise
-   *   that resolves a key ID to a DH public key.
-   * @param {number} [chunkSize=1048576] the size, in bytes, of the chunks to
+   * @param {object} options - Options for the transformer.
+   * @param {Array} options.recipients
+   * - An array of recipients for the encrypted content.
+   * @param {Function} options.keyResolver - A function that returns
+   * a Promise that resolves a key ID to a DH public key.
+   * @param {number} [options.chunkSize=1048576]
+   * - The size, in bytes, of the chunks to
    *   break the incoming data into (only applies if returning a stream).
    *
-   * @return {Promise<EncryptTransformer>} resolves to an EncryptTransformer.
+   * @returns {Promise<EncryptTransformer>} Resolves to an EncryptTransformer.
    */
   async createEncryptTransformer({recipients, keyResolver, chunkSize}) {
     if(!(Array.isArray(recipients) && recipients.length > 0)) {
@@ -259,7 +267,7 @@ export class Cipher {
   /**
    * Creates a DecryptTransformer.
    *
-   * @param {Object} keyAgreementKey - A key agreement key API with `id` and
+   * @param {object} keyAgreementKey - A key agreement key API with `id` and
    *   `deriveSecret`.
    *
    * @returns {Promise<DecryptTransformer>} Resolves to a DecryptTransformer.

--- a/Cipher.js
+++ b/Cipher.js
@@ -259,10 +259,10 @@ export class Cipher {
   /**
    * Creates a DecryptTransformer.
    *
-   * @param {Object} keyAgreementKey a key agreement key API with `id` and
+   * @param {Object} keyAgreementKey - A key agreement key API with `id` and
    *   `deriveSecret`.
    *
-   * @return {Promise<DecryptTransformer>} resolves to a DecryptTransformer.
+   * @returns {Promise<DecryptTransformer>} Resolves to a DecryptTransformer.
    */
   async createDecryptTransformer({keyAgreementKey}) {
     return new DecryptTransformer({

--- a/Cipher.js
+++ b/Cipher.js
@@ -53,7 +53,7 @@ export class Cipher {
    * in the `recipients` array will be updated to include the generated
    * ephemeral ECDH key.
    *
-   * @param {object} options - The options for the stream.
+   * @param {Object} options - The options for the stream.
    * @param {Array} options.recipients
    * - An array of recipients for the encrypted content.
    * @param {Function} options.keyResolver - A function that returns a Promise
@@ -82,8 +82,8 @@ export class Cipher {
    * (KEK) generated via a shared secret between an ephemeral ECDH key and a
    * static ECDH key (ECDH-ES).
    *
-   * @param {object} options - Options for createDecryptStream.
-   * @param {object} options.keyAgreementKey
+   * @param {Object} options - Options for createDecryptStream.
+   * @param {Object} options.keyAgreementKey
    * - A key agreement key API with `id` and deriveSecret`.
    *
    * @returns {Promise<TransformStream>} Resolves to the TransformStream.
@@ -104,14 +104,14 @@ export class Cipher {
    * in the `recipients` array will be updated to include the generated
    * ephemeral ECDH key.
    *
-   * @param {object} options - Options for encrypt.
+   * @param {Object} options - Options for encrypt.
    * @param {Uint8Array|string} [options.data] - The data to encrypt.
    * @param {Array} options.recipients
    * - An array of recipients for the encrypted content.
    * @param {Function} options.keyResolver - A function that returns a Promise
    *   that resolves a key ID to a DH public key.
    *
-   * @returns {Promise<object>} Resolves to a JWE.
+   * @returns {Promise<Object>} Resolves to a JWE.
    */
   async encrypt({data, recipients, keyResolver}) {
     if(!(data instanceof Uint8Array) && typeof data !== 'string') {
@@ -129,9 +129,9 @@ export class Cipher {
    * Encrypts an object. The object will be serialized to JSON and passed
    * to `encrypt`. See `encrypt` for other parameters.
    *
-   * @param {object} obj - The object to encrypt.
+   * @param {Object} obj - The object to encrypt.
    *
-   * @returns {Promise<object>} Resolves to a JWE.
+   * @returns {Promise<Object>} Resolves to a JWE.
    */
   async encryptObject({obj, ...rest}) {
     if(typeof obj !== 'object') {
@@ -150,13 +150,13 @@ export class Cipher {
    * (KEK) generated via a shared secret between an ephemeral ECDH key and a
    * static ECDH key (ECDH-ES).
    *
-   * @param {object} options - Options for decrypt.
-   * @param {object} options.jwe - The JWE to decrypt.
-   * @param {object} options.keyAgreementKey
+   * @param {Object} options - Options for decrypt.
+   * @param {Object} options.jwe - The JWE to decrypt.
+   * @param {Object} options.keyAgreementKey
    * - A key agreement key API with `id` and
    *   `deriveSecret`.
    *
-   * @returns {Promise<Uint8Array|null>} Resolves to the decrypted data
+   * @returns {Promise<Uint8Array>} Resolves to the decrypted data
    *   or `null` if the decryption failed.
    */
   async decrypt({jwe, keyAgreementKey}) {
@@ -169,12 +169,12 @@ export class Cipher {
    * Decrypts a JWE that must contain an encrypted object. This method will
    * call `decrypt` and then `JSON.parse` the resulting decrypted UTF-8 data.
    *
-   * @param {object} options - Options.
-   * @param {object} options.jwe - The JWE to decrypt.
-   * @param {object} options.keyAgreementKey
+   * @param {Object} options - Options.
+   * @param {Object} options.jwe - The JWE to decrypt.
+   * @param {Object} options.keyAgreementKey
    * - A key agreement key API with `id` and `deriveSecret`.
    *
-   * @returns {Promise<object|null>} Resolves to the decrypted object or `null`
+   * @returns {Promise<Object>} Resolves to the decrypted object or `null`
    *   if the decryption failed.
    */
   async decryptObject({jwe, keyAgreementKey}) {
@@ -196,7 +196,7 @@ export class Cipher {
    * in the `recipients` array will be updated to include the generated
    * ephemeral ECDH key.
    *
-   * @param {object} options - Options for the transformer.
+   * @param {Object} options - Options for the transformer.
    * @param {Array} options.recipients
    * - An array of recipients for the encrypted content.
    * @param {Function} options.keyResolver - A function that returns
@@ -267,7 +267,7 @@ export class Cipher {
   /**
    * Creates a DecryptTransformer.
    *
-   * @param {object} keyAgreementKey - A key agreement key API with `id` and
+   * @param {Object} keyAgreementKey - A key agreement key API with `id` and
    *   `deriveSecret`.
    *
    * @returns {Promise<DecryptTransformer>} Resolves to a DecryptTransformer.

--- a/algorithms/aeskw.js
+++ b/algorithms/aeskw.js
@@ -17,7 +17,7 @@ class Kek {
    *
    * @param {Object} options - The options to use.
    * @param {Uint8Array} options.unwrappedKey - The key material as a
-   *   Uint8Array.
+   *   `Uint8Array`.
    *
    * @returns {Promise<string>} The base64url-encoded wrapped key bytes.
    */
@@ -25,6 +25,7 @@ class Kek {
     const kek = this.key;
     // Note: `AES-GCM` algorithm name doesn't matter; will be exported raw.
     const extractable = true;
+
     unwrappedKey = await crypto.subtle.importKey(
       'raw', unwrappedKey, {name: 'AES-GCM', length: 256},
       extractable, ['encrypt']);
@@ -40,7 +41,7 @@ class Kek {
    * @param {string} options.wrappedKey - The wrapped key material as a
    *   base64url-encoded string.
    *
-   * @returns {Promise<Uint8Array|null>} Resolves to the key bytes or null if
+   * @returns {Promise<Uint8Array>} Resolves to the key bytes or null if
    *   the unwrapping fails because the key does not match.
    */
   async unwrapKey({wrappedKey}) {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
     "test": "cd test && npm run test-node",
     "test-node": "cd test && npm run test-node",
     "test-karma": "cd test && karma start karma.conf.js",
-    "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm run test-node",
-    "coverage-report": "cd test && nyc report",
     "lint": "eslint ."
   },
   "files": [
@@ -58,7 +56,6 @@
     "karma-webpack": "^3.0.5",
     "mocha": "^6.1.2",
     "mocha-lcov-reporter": "^1.3.0",
-    "nyc": "^14.0.0",
     "webpack": "^4.29.6"
   },
   "repository": {
@@ -91,14 +88,5 @@
   },
   "engines": {
     "node": ">=8.6.0"
-  },
-  "nyc": {
-    "exclude": [
-      "tests"
-    ],
-    "reporter": [
-      "html",
-      "text-summary"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "BSD-3-Clause",
   "main": "index.js",
   "scripts": {
-    "test": "npm run test-node",
-    "test-node": "cross-env NODE_ENV=test mocha -r esm --preserve-symlinks -t 30000 -A -R ${REPORTER:-spec} --require tests/test-mocha.js tests/*.spec.js",
+    "test": "cd test && npm run test-node",
+    "test-node": "cd test && cross-env NODE_ENV=test mocha -r esm --preserve-symlinks -t 30000 -A -R ${REPORTER:-spec} --require tests/test-mocha.js tests/*.spec.js",
     "test-karma": "karma start karma.conf.js",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm run test-node",
     "coverage-report": "nyc report",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test-node": "cd test && npm run test-node",
     "test-karma": "cd test && karma start karma.conf.js",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm run test-node",
-    "coverage-report": "nyc report",
+    "coverage-report": "cd test && nyc report",
     "lint": "eslint ."
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "index.js",
   "scripts": {
     "test": "cd test && npm run test-node",
-    "test-node": "cd test && cross-env NODE_ENV=test mocha -r esm --preserve-symlinks -t 30000 -A -R ${REPORTER:-spec} --require tests/test-mocha.js tests/*.spec.js",
-    "test-karma": "karma start karma.conf.js",
+    "test-node": "cd test && npm run test-node",
+    "test-karma": "cd test && karma start karma.conf.js",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm run test-node",
     "coverage-report": "nyc report",
     "lint": "eslint ."

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "cross-env": "^5.2.0",
     "eslint": "^5.16.0",
     "eslint-config-digitalbazaar": "^2.0.0",
+    "eslint-plugin-jsdoc": "^15.8.0",
     "karma": "^4.0.1",
     "karma-babel-preprocessor": "^8.0.0",
     "karma-chai": "^0.1.0",

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  env: {
+    browser: true,
+    mocha: true
+  }
+}

--- a/test/KaK.js
+++ b/test/KaK.js
@@ -1,4 +1,4 @@
-const bs58 = require('bs58');
+const base58 = require('../base58');
 const nacl = require('tweetnacl');
 
 class KaK {
@@ -12,11 +12,11 @@ class KaK {
   }
 
   async deriveSecret({publicKey}) {
-    const remotePublicKey = bs58.decode(publicKey.publicKeyBase58);
+    const remotePublicKey = base58.decode(publicKey.publicKeyBase58);
     return nacl.scalarMult(this.privateKey, remotePublicKey);
   }
   base58Encode(x) {
-    return bs58.encode(Buffer.from(x.buffer, x.byteOffset, x.byteLength));
+    return base58.encode(x);
   }
 }
 

--- a/test/KaK.js
+++ b/test/KaK.js
@@ -1,0 +1,23 @@
+const bs58 = require('bs58');
+const nacl = require('tweetnacl');
+
+class KaK {
+  constructor() {
+    const keyPair = nacl.box.keyPair();
+    this.id = 'urn:123',
+    this.type = 'X25519KeyAgreementKey2019';
+    this.privateKey = keyPair.secretKey;
+    this.publicKey = keyPair.publicKey;
+    this.publicKeyBase58 = this.base58Encode(this.publicKey);
+  }
+
+  async deriveSecret({publicKey}) {
+    const remotePublicKey = bs58.decode(publicKey.publicKeyBase58);
+    return nacl.scalarMult(this.privateKey, remotePublicKey);
+  }
+  base58Encode(x) {
+    return bs58.encode(Buffer.from(x.buffer, x.byteOffset, x.byteLength));
+  }
+}
+
+module.exports = KaK;

--- a/test/base58esm.js
+++ b/test/base58esm.js
@@ -1,0 +1,3 @@
+// translate `main.js` to CommonJS
+require = require('esm')(module);
+module.exports = require('../base58.js');

--- a/test/base58esm.js
+++ b/test/base58esm.js
@@ -1,3 +1,0 @@
-// translate `main.js` to CommonJS
-require = require('esm')(module);
-module.exports = require('../base58.js');

--- a/test/chai-cipher.js
+++ b/test/chai-cipher.js
@@ -1,0 +1,22 @@
+module.exports = function(chai) {
+  const {Assertion} = chai;
+  Assertion.addProperty('JWE', function() {
+    const jwe = this._obj;
+    new Assertion(jwe).to.be.an('object');
+    new Assertion(jwe.protected).to.exist;
+    new Assertion(jwe.protected).to.be.a(
+      'string', 'Expected the property protected to be a string.');
+    new Assertion(jwe.recipients).to.exist;
+    new Assertion(jwe.recipients).to.be.an(
+      'array', 'Expected JWE recipients to be an array.');
+    new Assertion(jwe.iv).to.exist;
+    new Assertion(jwe.iv).to.be.a(
+      'string', 'Expected JWE Initialization Vector to be a string.');
+    new Assertion(jwe.ciphertext).to.exist;
+    new Assertion(jwe.ciphertext).to.be.a(
+      'string', 'Expected JWE ciphertext to be a string.');
+    new Assertion(jwe.tag).to.exist;
+    new Assertion(jwe.tag).to.be.a(
+      'string', 'Expected JWE tag to be a string');
+  });
+};

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,0 +1,38 @@
+module.exports = function(config) {
+  // bundler to test: webpack, browserify
+  const bundler = process.env.BUNDLER || 'webpack';
+  const frameworks = ['mocha'];
+  const files = ['unit/index.js'];
+  const reports = ['mocha'];
+  const browsers = ['ChromeHeadless'];
+  const client = {
+    mocha: {
+      timeout: 2000
+    }
+  };
+  // main bundle preprocessors
+  const preprocessors = [];
+  preprocessors.push(bundler);
+  preprocessors.push('sourcemap');
+
+  return config.set({
+    frameworks, files, reports,
+    basePath: '', port: 9876, colors: true,
+    browsers, client,
+    // preprocess matching files before serving them to the browser
+    // available preprocessors:
+    // https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+      'unit/*.js': preprocessors,
+    },
+    webpack: {
+      devtool: 'inline-source-map',
+      mode: 'development',
+      node: {
+        Buffer: false,
+        crypto: false,
+        setImmediate: false
+      }
+    }
+  });
+};

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -3,7 +3,7 @@ module.exports = function(config) {
   const bundler = process.env.BUNDLER || 'webpack';
   const frameworks = ['mocha'];
   const files = ['unit/index.js'];
-  const reports = ['mocha'];
+  const reporters = ['mocha'];
   const browsers = ['ChromeHeadless'];
   const client = {
     mocha: {
@@ -16,7 +16,7 @@ module.exports = function(config) {
   preprocessors.push('sourcemap');
 
   return config.set({
-    frameworks, files, reports,
+    frameworks, files, reporters,
     basePath: '', port: 9876, colors: true,
     browsers, client,
     // preprocess matching files before serving them to the browser

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function(config) {
   return config.set({
     frameworks, files, reporters,
     basePath: '', port: 9876, colors: true,
-    browsers, client,
+    browsers, client, singleRun: true,
     // preprocess matching files before serving them to the browser
     // available preprocessors:
     // https://npmjs.org/browse/keyword/karma-preprocessor

--- a/test/package.json
+++ b/test/package.json
@@ -31,7 +31,6 @@
     "karma-webpack": "^4.0.2",
     "mocha": "^6.2.0",
     "mocha-lcov-reporter": "^1.3.0",
-    "nyc": "^14.1.1",
     "webpack": "^4.39.1"
   },
   "dependencies": {}

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "minimal-cipher-test-project",
+  "version": "0.0.1",
+  "description": "Unit Tests in Mocha and Karma for Minimal Cipher.",
+  "main": "index.js",
+  "scripts": {
+    "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} unit/index.js"
+  },
+  "keywords": [
+    "test",
+    "minimal-cipher"
+  ],
+  "author": {
+    "name": "Digital Bazaar, Inc.",
+    "email": "support@digitalbazaar.com",
+    "url": "http://digitalbazaar.com/"
+  },
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "cross-env": "^5.2.0",
+    "karma": "^4.2.0",
+    "karma-chrome-launcher": "^3.0.0",
+    "karma-edge-launcher": "^0.4.2",
+    "karma-firefox-launcher": "^1.1.0",
+    "karma-ie-launcher": "^1.0.0",
+    "karma-mocha": "^1.3.0",
+    "karma-mocha-reporter": "^2.2.5",
+    "karma-sauce-launcher": "^2.0.2",
+    "mocha": "^6.2.0",
+    "mocha-lcov-reporter": "^1.3.0",
+    "nyc": "^14.1.1"
+  }
+}

--- a/test/package.json
+++ b/test/package.json
@@ -29,5 +29,8 @@
     "mocha": "^6.2.0",
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^14.1.1"
+  },
+  "dependencies": {
+    "bs58": "^4.0.1"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,8 @@
   "description": "Unit Tests in Mocha and Karma for Minimal Cipher.",
   "main": "index.js",
   "scripts": {
-    "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} unit/index.js"
+    "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} unit/index.js",
+    "test-karma": "karma start"
   },
   "keywords": [
     "test",
@@ -26,11 +27,12 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sauce-launcher": "^2.0.2",
+    "karma-sourcemap-loader": "^0.3.7",
+    "karma-webpack": "^4.0.2",
     "mocha": "^6.2.0",
     "mocha-lcov-reporter": "^1.3.0",
-    "nyc": "^14.1.1"
+    "nyc": "^14.1.1",
+    "webpack": "^4.39.1"
   },
-  "dependencies": {
-    "bs58": "^4.0.1"
-  }
+  "dependencies": {}
 }

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
   "description": "Unit Tests in Mocha and Karma for Minimal Cipher.",
   "main": "index.js",
   "scripts": {
-    "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} unit/index.js",
+    "test-node": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} unit/index.js",
     "test-karma": "karma start"
   },
   "keywords": [

--- a/test/package.json
+++ b/test/package.json
@@ -30,7 +30,6 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^4.0.2",
     "mocha": "^6.2.0",
-    "mocha-lcov-reporter": "^1.3.0",
     "webpack": "^4.39.1"
   },
   "dependencies": {}

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,7 +1,8 @@
 const chai = require('chai');
-const {Cipher} = require('../../index');
+const {Cipher} = require('../../');
 const KaK = require('../KaK');
 const chaiCipher = require('../chai-cipher');
+
 chai.should();
 chai.use(chaiCipher);
 

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -84,8 +84,9 @@ describe('minimal-cipher should use ', function() {
             throw e;
           }
         }
-        const buf = Buffer.concat(data);
-        return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+        // FIXME Buffer is not in browser
+        // this works fine however in all tests.
+        return Uint8Array.from(data);
       }
 
       it('to encrypt a simple Uint8Array', async function() {

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -32,6 +32,11 @@ describe('minimal-cipher should use ', function() {
         }];
       });
 
+      function getRandomUint8({size = 50} = {}) {
+        return new Uint8Array(size).map(
+          () => Math.floor(Math.random() * 255));
+      }
+
       async function encryptStream({data}) {
         const encryptStream = await cipher.createEncryptStream(
           {recipients, keyResolver, chunkSize: 1});
@@ -84,7 +89,7 @@ describe('minimal-cipher should use ', function() {
       }
 
       it('to encrypt a simple Uint8Array', async function() {
-        const data = new Uint8Array([0x01, 0x02, 0x03]);
+        const data = getRandomUint8();
         const result = await cipher.encrypt({data, recipients, keyResolver});
         result.should.be.a.JWE;
       });
@@ -103,7 +108,7 @@ describe('minimal-cipher should use ', function() {
       });
 
       it('to encrypt a stream', async function() {
-        const data = new Uint8Array([0x01, 0x02, 0x03]);
+        const data = getRandomUint8();
         const chunks = await encryptStream({data});
         chunks.length.should.be.gte(0);
         for(const chunk of chunks) {
@@ -111,8 +116,8 @@ describe('minimal-cipher should use ', function() {
         }
       });
 
-      it('to decrypt a simple Uint8Array', async function() {
-        const data = new Uint8Array([0x01, 0x02, 0x03]);
+      it('to decrypt an Uint8Array', async function() {
+        const data = getRandomUint8();
         const jwe = await cipher.encrypt({data, recipients, keyResolver});
         jwe.should.be.a.JWE;
         const result = await cipher.decrypt({jwe, keyAgreementKey});
@@ -138,7 +143,7 @@ describe('minimal-cipher should use ', function() {
       });
 
       it('to decrypt a stream', async function() {
-        const data = new Uint8Array([0x01, 0x02, 0x03]);
+        const data = getRandomUint8();
         const chunks = await encryptStream({data});
         chunks.length.should.be.gte(0);
         for(const chunk of chunks) {
@@ -148,7 +153,6 @@ describe('minimal-cipher should use ', function() {
         result.length.should.be.gte(0);
         result.should.deep.eql(data);
       });
-
     });
   });
 });

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -42,6 +42,20 @@ describe('minimal-cipher', function() {
       }
 
       async function encryptStream({data}) {
+        /* TODO: consider using pipeThrough pattern instead to catch errors
+        ... as now `writer.write` errors won't be caught
+        const stream = new Readable({
+          pull(controller) {
+            controller.enqueue(new Uint8Array([0x01, 0x02, 0x03]));
+            controller.close();
+          }
+        });
+
+        const encryptStream = await cipher.createEncryptStream(...);
+        const readable = stream.pipeThrough(encryptStream);
+        const reader = readable.getReader();
+
+        while(...)*/
         const encryptStream = await cipher.createEncryptStream(
           {recipients, keyResolver, chunkSize: 1});
         const writer = encryptStream.writable.getWriter();

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,0 +1,34 @@
+const {Cipher} = require('../../index');
+const base58 = require('../base58esm');
+
+const cipherAlgorithms = ['recommended', 'fips'];
+
+describe('minimal-cipher should use ', function() {
+  cipherAlgorithms.forEach(algorithm => {
+    describe(`the ${algorithm} algorithm`, function() {
+      let cipher, keyPair, publicKeyNode = null;
+      const keyResolver = async () => publicKeyNode
+      beforeEach(async function() {
+        cipher = new Cipher({version: algorithm});
+        keyPair = await cipher.keyAgreement.deriveEphemeralKeyPair();
+        publicKeyNode = {
+          '@context': 'https://w3id.org/security/v2',
+          id: 'urn:123',
+          type: 'X25519KeyAgreementKey2019',
+          publicKeyBase58: base58.encode(keyPair.publicKey)
+        };
+      });
+      it('to encrypt some simple bites', async function() {
+        const data = new Uint8Array([0x01, 0x02, 0x03]);
+        const recipients = [{
+          header: {kid: publicKeyNode.id}
+        }];
+        const result = await cipher.encrypt({data, recipients, keyResolver});
+        console.log(result);
+      });
+      it('to encrypt a stream', async function() {
+
+      });
+    });
+  });
+});

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,13 +1,22 @@
+const chai = require('chai');
 const {Cipher} = require('../../index');
 const base58 = require('../base58esm');
+const chaiCipher = require('../chai-cipher');
+chai.should();
+chai.use(chaiCipher);
 
 const cipherAlgorithms = ['recommended', 'fips'];
 
 describe('minimal-cipher should use ', function() {
   cipherAlgorithms.forEach(algorithm => {
     describe(`the ${algorithm} algorithm`, function() {
-      let cipher, keyPair, publicKeyNode = null;
-      const keyResolver = async () => publicKeyNode
+
+      // each test inits data to null
+      let cipher, keyPair, publicKeyNode, recipients = null;
+
+      // keyResolver returns publicKeyNode
+      const keyResolver = async () => publicKeyNode;
+
       beforeEach(async function() {
         cipher = new Cipher({version: algorithm});
         keyPair = await cipher.keyAgreement.deriveEphemeralKeyPair();
@@ -17,18 +26,27 @@ describe('minimal-cipher should use ', function() {
           type: 'X25519KeyAgreementKey2019',
           publicKeyBase58: base58.encode(keyPair.publicKey)
         };
-      });
-      it('to encrypt some simple bites', async function() {
-        const data = new Uint8Array([0x01, 0x02, 0x03]);
-        const recipients = [{
-          header: {kid: publicKeyNode.id}
+        recipients = [{
+          header: {kid: publicKeyNode.id, alg: 'ECDH-ES+A256KW'}
         }];
-        const result = await cipher.encrypt({data, recipients, keyResolver});
-        console.log(result);
       });
-      it('to encrypt a stream', async function() {
+
+      it('to encrypt a simple Uint8Array', async function() {
+        const data = new Uint8Array([0x01, 0x02, 0x03]);
+        const result = await cipher.encrypt({data, recipients, keyResolver});
+        result.should.be.a.JWE;
+      });
+
+      it('to encrypt a simple string', async function() {
+        const data = 'simple';
+        const result = await cipher.encrypt({data, recipients, keyResolver});
+        result.should.be.a.JWE;
+      });
+
+      it.skip('to encrypt a stream', async function() {
 
       });
+
     });
   });
 });

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -43,6 +43,13 @@ describe('minimal-cipher should use ', function() {
         result.should.be.a.JWE;
       });
 
+      it('to encrypt a simple object', async function() {
+        const obj = {simple: true};
+        const result = await cipher.encryptObject(
+          {obj, recipients, keyResolver});
+        result.should.be.a.JWE;
+      });
+
       it.skip('to encrypt a stream', async function() {
 
       });

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,5 +1,9 @@
+/*!
+ * Copyright (c) 2019 Digital Bazaar, Inc. All rights reserved.
+ */
 const chai = require('chai');
 const {Cipher} = require('../../');
+const {TextDecoder} = require('../../util');
 const KaK = require('../KaK');
 const chaiCipher = require('../chai-cipher');
 
@@ -8,9 +12,9 @@ chai.use(chaiCipher);
 
 const cipherAlgorithms = ['recommended', 'fips'];
 
-describe('minimal-cipher should use ', function() {
+describe('minimal-cipher', function() {
   cipherAlgorithms.forEach(algorithm => {
-    describe(`the ${algorithm} algorithm`, function() {
+    describe(`${algorithm} algorithm`, function() {
 
       // each test inits data to null
       let cipher, keyAgreementKey, publicKeyNode, recipients = null;
@@ -89,26 +93,26 @@ describe('minimal-cipher should use ', function() {
         return Uint8Array.from(data);
       }
 
-      it('to encrypt a simple Uint8Array', async function() {
+      it('should encrypt a simple Uint8Array', async function() {
         const data = getRandomUint8();
         const result = await cipher.encrypt({data, recipients, keyResolver});
         result.should.be.a.JWE;
       });
 
-      it('to encrypt a simple string', async function() {
+      it('should encrypt a simple string', async function() {
         const data = 'simple';
         const result = await cipher.encrypt({data, recipients, keyResolver});
         result.should.be.a.JWE;
       });
 
-      it('to encrypt a simple object', async function() {
+      it('should encrypt a simple object', async function() {
         const obj = {simple: true};
         const result = await cipher.encryptObject(
           {obj, recipients, keyResolver});
         result.should.be.a.JWE;
       });
 
-      it('to encrypt a stream', async function() {
+      it('should encrypt a stream', async function() {
         const data = getRandomUint8();
         const chunks = await encryptStream({data});
         chunks.length.should.be.gte(0);
@@ -117,7 +121,7 @@ describe('minimal-cipher should use ', function() {
         }
       });
 
-      it('to decrypt an Uint8Array', async function() {
+      it('should decrypt an Uint8Array', async function() {
         const data = getRandomUint8();
         const jwe = await cipher.encrypt({data, recipients, keyResolver});
         jwe.should.be.a.JWE;
@@ -125,16 +129,16 @@ describe('minimal-cipher should use ', function() {
         result.should.deep.equal(data);
       });
 
-      it('to decrypt a simple string', async function() {
+      it('should decrypt a simple string', async function() {
         const data = 'simple';
         const jwe = await cipher.encrypt({data, recipients, keyResolver});
         jwe.should.be.a.JWE;
         const result = await cipher.decrypt({jwe, keyAgreementKey});
-        const resultString = new TextDecoder('utf-8').decode(result);
+        const resultString = new TextDecoder().decode(result);
         resultString.should.deep.equal(data);
       });
 
-      it('to decrypt a simple object', async function() {
+      it('should decrypt a simple object', async function() {
         const obj = {simple: true};
         const jwe = await cipher.encryptObject(
           {obj, recipients, keyResolver});
@@ -143,7 +147,7 @@ describe('minimal-cipher should use ', function() {
         result.should.deep.equal(obj);
       });
 
-      it('to decrypt a stream', async function() {
+      it('should decrypt a stream', async function() {
         const data = getRandomUint8();
         const chunks = await encryptStream({data});
         chunks.length.should.be.gte(0);

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,6 +1,6 @@
 const chai = require('chai');
 const {Cipher} = require('../../index');
-const base58 = require('../base58esm');
+const KaK = require('../KaK');
 const chaiCipher = require('../chai-cipher');
 chai.should();
 chai.use(chaiCipher);
@@ -12,22 +12,22 @@ describe('minimal-cipher should use ', function() {
     describe(`the ${algorithm} algorithm`, function() {
 
       // each test inits data to null
-      let cipher, keyPair, publicKeyNode, recipients = null;
+      let cipher, keyAgreementKey, publicKeyNode, recipients = null;
 
       // keyResolver returns publicKeyNode
       const keyResolver = async () => publicKeyNode;
 
       beforeEach(async function() {
         cipher = new Cipher({version: algorithm});
-        keyPair = await cipher.keyAgreement.deriveEphemeralKeyPair();
+        keyAgreementKey = new KaK();
         publicKeyNode = {
           '@context': 'https://w3id.org/security/v2',
-          id: 'urn:123',
-          type: 'X25519KeyAgreementKey2019',
-          publicKeyBase58: base58.encode(keyPair.publicKey)
+          id: keyAgreementKey.id,
+          type: keyAgreementKey.type,
+          publicKeyBase58: keyAgreementKey.publicKeyBase58
         };
         recipients = [{
-          header: {kid: publicKeyNode.id, alg: 'ECDH-ES+A256KW'}
+          header: {kid: keyAgreementKey.id, alg: 'ECDH-ES+A256KW'}
         }];
       });
 
@@ -50,8 +50,30 @@ describe('minimal-cipher should use ', function() {
         result.should.be.a.JWE;
       });
 
-      it.skip('to encrypt a stream', async function() {
+      it('to decrypt a simple Uint8Array', async function() {
+        const data = new Uint8Array([0x01, 0x02, 0x03]);
+        const jwe = await cipher.encrypt({data, recipients, keyResolver});
+        jwe.should.be.a.JWE;
+        const result = await cipher.decrypt({jwe, keyAgreementKey});
+        result.should.deep.equal(data);
+      });
 
+      it('to decrypt a simple string', async function() {
+        const data = 'simple';
+        const jwe = await cipher.encrypt({data, recipients, keyResolver});
+        jwe.should.be.a.JWE;
+        const result = await cipher.decrypt({jwe, keyAgreementKey});
+        const resultString = new TextDecoder('utf-8').decode(result);
+        resultString.should.deep.equal(data);
+      });
+
+      it('to decrypt a simple object', async function() {
+        const obj = {simple: true};
+        const jwe = await cipher.encryptObject(
+          {obj, recipients, keyResolver});
+        jwe.should.be.a.JWE;
+        const result = await cipher.decryptObject({jwe, keyAgreementKey});
+        result.should.deep.equal(obj);
       });
 
     });


### PR DESCRIPTION
My apologies if this is not implemented correctly.

All tests pass in both node and karma however weirdly using the ponyfill for ReadableStream is failing in Chrome Headless so I just stuck with the code from the issue:

https://github.com/digitalbazaar/minimal-cipher/issues/1

I removed the nyc coverage as it is unable to track require statements inside of esm modules it appears. I googled around for this, but figured with a project as small as this taking the time to fix the nyc coverage might be too much effort.

I also linted the jsdoc comments for Cipher.js

There is also a custom chai assertion

```
data.should.be.a.JWE
```

that checks the format of a JWE and can re-used in further tests.